### PR TITLE
feat: added global form component with request aid data

### DIFF
--- a/interfaces/request-aid.ts
+++ b/interfaces/request-aid.ts
@@ -1,0 +1,28 @@
+import { ObjectPronounType, SubjectPronounType } from '@custom-types/pronouns';
+
+export default interface RequestAidInterface {
+	name: string;
+	subjectPronoun: SubjectPronounType;
+	objectPronoun: ObjectPronounType;
+	language: string;
+	phone: string;
+	email: string;
+	preferredContactMethod: 'call' | 'text' | 'email';
+	location: string;
+	hasHearingDisability: boolean;
+	hasTransportation: boolean;
+	hasFluLikeSymptoms: boolean;
+	hasHealthCondition: boolean;
+	healthConditions: string;
+	is18: boolean;
+	needsPickup: boolean;
+	needsTransportation: boolean;
+	needsMedicalSupplies: boolean;
+	needsCleaningSupplies: boolean;
+	needsHomeCookedMeal: boolean;
+	needHomeCleaning: boolean;
+	needsCompanionship: boolean;
+	needsSocialServices: boolean;
+	needsPetCare: boolean;
+	needsOther: string;
+}

--- a/src/components/organisms/Form/index.tsx
+++ b/src/components/organisms/Form/index.tsx
@@ -11,6 +11,7 @@ export interface InputInterface {
 	label: string;
 	options?: Array<string>;
 	placeholder?: string;
+	size?: 'sm' | 'md' | 'lg';
 }
 
 export interface FormDataInterface extends InputInterface {
@@ -65,8 +66,12 @@ const StyledForm = styled(
 									placeholder,
 									label,
 									options,
+									size,
 								}) => (
-									<BSForm.Group className="mb-3" key={name}>
+									<BSForm.Group
+										className={`mb-3 ${size}`}
+										key={name}
+									>
 										{type === 'text' && (
 											<>
 												<BSForm.Label>
@@ -137,6 +142,7 @@ const Form = ({ onSubmit, data, submitButtonText }: FormPropsInterface) => {
 			{
 				name,
 				type,
+				size,
 				placeholder,
 				initialValue,
 				label,
@@ -145,7 +151,10 @@ const Form = ({ onSubmit, data, submitButtonText }: FormPropsInterface) => {
 			}
 		) => ({
 			initialValues: { ...initialValues, [name]: initialValue },
-			inputs: [...inputs, { type, name, placeholder, label, options }],
+			inputs: [
+				...inputs,
+				{ type, name, placeholder, label, options, size },
+			],
 		}),
 		{ initialValues: {}, inputs: [] }
 	);

--- a/src/components/organisms/Form/index.tsx
+++ b/src/components/organisms/Form/index.tsx
@@ -1,0 +1,162 @@
+import { Formik } from 'formik';
+import styled, { StyledComponent } from 'styled-components';
+import { HTMLInputTypeAttribute } from 'react';
+import style from './style';
+import * as yup from 'yup';
+import { Button, Form as BSForm } from 'react-bootstrap';
+
+export interface InputInterface {
+	type: HTMLInputTypeAttribute;
+	name: string;
+	label: string;
+	options?: Array<string>;
+	placeholder?: string;
+}
+
+export interface FormDataInterface extends InputInterface {
+	initialValue: string | boolean;
+	validationSchema: yup.AnySchema;
+}
+
+export interface FormPropsInterface {
+	data: Array<FormDataInterface>;
+	onSubmit: any;
+	submitButtonText?: string;
+}
+
+export interface InitialValueInterface {
+	[key: string]: string | number;
+}
+
+export interface StyledFormInterface {
+	className: string;
+	initialValues: InitialValueInterface;
+	validationSchema: yup.AnySchema;
+	onSubmit: any;
+	inputs: any;
+	submitButtonText?: string;
+}
+
+const StyledForm = styled(
+	({
+		className,
+		inputs,
+		initialValues,
+		submitButtonText,
+		onSubmit,
+		validationSchema,
+	}: StyledFormInterface): StyledComponent => (
+		<Formik
+			className={className}
+			initialValues={initialValues}
+			onSubmit={onSubmit}
+			validationSchema={validationSchema}
+			validateOnChange={false}
+			validateOnBlur={false}
+		>
+			{({ values, handleChange, handleSubmit, isSubmitting }) => (
+				<>
+					<BSForm className={className} onSubmit={handleSubmit}>
+						{inputs &&
+							inputs.map(
+								({
+									name,
+									type,
+									placeholder,
+									label,
+									options,
+								}) => (
+									<BSForm.Group className="mb-3" key={name}>
+										{type === 'text' && (
+											<>
+												<BSForm.Label>
+													{label}
+												</BSForm.Label>
+												<BSForm.Control
+													type={type}
+													name={name}
+													placeholder={placeholder}
+													onChange={handleChange}
+													value={values[name]}
+												/>
+											</>
+										)}
+										{type === 'checkbox' && (
+											<BSForm.Check
+												type={type}
+												name={name}
+												placeholder={placeholder}
+												onChange={handleChange}
+												value={values[name]}
+												label={label}
+											/>
+										)}
+										{type === 'select' && (
+											<>
+												<BSForm.Label>
+													{label}
+												</BSForm.Label>
+												<BSForm.Select
+													name={name}
+													placeholder={placeholder}
+													onChange={handleChange}
+													value={values[name]}
+												>
+													{options.map((option) => (
+														<option key={option}>
+															{option}
+														</option>
+													))}
+												</BSForm.Select>
+											</>
+										)}
+									</BSForm.Group>
+								)
+							)}
+						<Button type="submit" disabled={isSubmitting}>
+							{submitButtonText || 'Submit'}
+						</Button>
+					</BSForm>
+				</>
+			)}
+		</Formik>
+	)
+)(style);
+
+const Form = ({ onSubmit, data, submitButtonText }: FormPropsInterface) => {
+	let validationSchema = yup.object().shape({});
+	const {
+		initialValues,
+		inputs,
+	}: {
+		initialValues: InitialValueInterface;
+		inputs: Array<InputInterface>;
+	} = data.reduce(
+		(
+			{ initialValues, inputs },
+			{
+				name,
+				type,
+				placeholder,
+				initialValue,
+				label,
+				options,
+				validationSchema: validation,
+			}
+		) => ({
+			initialValues: { ...initialValues, [name]: initialValue },
+			inputs: [...inputs, { type, name, placeholder, label, options }],
+		}),
+		{ initialValues: {}, inputs: [] }
+	);
+	return (
+		<StyledForm
+			onSubmit={onSubmit}
+			initialValues={initialValues}
+			inputs={inputs}
+			submitButtonText={submitButtonText}
+		/>
+	);
+};
+
+export default Form;

--- a/src/components/organisms/Form/index.tsx
+++ b/src/components/organisms/Form/index.tsx
@@ -11,7 +11,7 @@ export interface InputInterface {
 	label: string;
 	options?: Array<string>;
 	placeholder?: string;
-	size?: 'sm' | 'md' | 'lg';
+	size?: 'xsm' | 'sm';
 }
 
 export interface FormDataInterface extends InputInterface {

--- a/src/components/organisms/Form/style.ts
+++ b/src/components/organisms/Form/style.ts
@@ -1,4 +1,10 @@
 const style = () => ({
+	'input, select': {
+		maxWidth: '500px',
+	},
+	'.sm > input, .sm > select': {
+		maxWidth: '250px',
+	},
 });
 
 export default style;

--- a/src/components/organisms/Form/style.ts
+++ b/src/components/organisms/Form/style.ts
@@ -1,0 +1,4 @@
+const style = () => ({
+});
+
+export default style;

--- a/src/components/organisms/Form/style.ts
+++ b/src/components/organisms/Form/style.ts
@@ -5,6 +5,9 @@ const style = () => ({
 	'.sm > input, .sm > select': {
 		maxWidth: '250px',
 	},
+	'.xsm > input, .xsm > select': {
+		maxWidth: '125px',
+	},
 });
 
 export default style;

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -20,8 +20,8 @@ const Header: StyledComponent = styled(({ className }) => {
 								Used by organizations, collectives, volunteers,
 								and service providers.
 							</p>
-							<Link to="/listings">
-								<Button variant="dark">Browse Listings</Button>
+							<Link to="/request">
+								<Button variant="dark">Request Aid</Button>
 							</Link>
 							<Link to="/create-account">
 								<Button variant="secondary">

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -20,6 +20,7 @@ const formData: Array<FormDataInterface> = [
 		options: SUBJECT_PRONOUNS,
 		validationSchema: yup.string().label('Subject Pronoun').required(),
 		label: 'Subject Pronoun',
+		size: 'sm',
 	},
 	{
 		name: 'objectPronoun',
@@ -28,6 +29,7 @@ const formData: Array<FormDataInterface> = [
 		options: OBJECT_PRONOUNS,
 		validationSchema: yup.string().label('Object Pronoun').required(),
 		label: 'Object Pronoun',
+		size: 'sm',
 	},
 	{
 		name: 'language',
@@ -36,6 +38,7 @@ const formData: Array<FormDataInterface> = [
 		options: ['English', 'Spanish', 'Vietnamese'],
 		validationSchema: yup.string().label('Language').required(),
 		label: 'Language',
+		size: 'sm',
 	},
 	{
 		name: 'phone',
@@ -58,6 +61,7 @@ const formData: Array<FormDataInterface> = [
 		options: ['Email', 'Call', 'Text'],
 		validationSchema: yup.string().label('Email').required(),
 		label: 'Preferred Contact Method',
+		size: 'sm',
 	},
 	{
 		name: 'location',

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -20,7 +20,7 @@ const formData: Array<FormDataInterface> = [
 		options: SUBJECT_PRONOUNS,
 		validationSchema: yup.string().label('Subject Pronoun').required(),
 		label: 'Subject Pronoun',
-		size: 'sm',
+		size: 'xsm',
 	},
 	{
 		name: 'objectPronoun',
@@ -29,7 +29,7 @@ const formData: Array<FormDataInterface> = [
 		options: OBJECT_PRONOUNS,
 		validationSchema: yup.string().label('Object Pronoun').required(),
 		label: 'Object Pronoun',
-		size: 'sm',
+		size: 'xsm',
 	},
 	{
 		name: 'language',
@@ -61,7 +61,7 @@ const formData: Array<FormDataInterface> = [
 		options: ['Email', 'Call', 'Text'],
 		validationSchema: yup.string().label('Email').required(),
 		label: 'Preferred Contact Method',
-		size: 'sm',
+		size: 'xsm',
 	},
 	{
 		name: 'location',

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -2,35 +2,8 @@ import { Container } from 'react-bootstrap';
 import Form from '@organisms/Form';
 import * as yup from 'yup';
 import { FormDataInterface } from '@organisms/Form';
-import { ObjectPronounType, SubjectPronounType } from '@custom-types/pronouns';
 import { OBJECT_PRONOUNS, SUBJECT_PRONOUNS } from '@objects/pronouns';
-
-export interface RequestAidInterface {
-	name: string;
-	subjectPronoun: SubjectPronounType;
-	objectPronoun: ObjectPronounType;
-	language: string;
-	phone: string;
-	email: string;
-	preferredContactMethod: 'call' | 'text' | 'email';
-	location: string;
-	hasHearingDisability: boolean;
-	hasTransportation: boolean;
-	hasFluLikeSymptoms: boolean;
-	hasHealthCondition: boolean;
-	healthConditions: string;
-	is18: boolean;
-	needsPickup: boolean;
-	needsTransportation: boolean;
-	needsMedicalSupplies: boolean;
-	needsCleaningSupplies: boolean;
-	needsHomeCookedMeal: boolean;
-	needHomeCleaning: boolean;
-	needsCompanionship: boolean;
-	needsSocialServices: boolean;
-	needsPetCare: boolean;
-	needsOther: string;
-}
+import RequestAidInterface from '@interfaces/request-aid';
 
 const formData: Array<FormDataInterface> = [
 	{

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -1,0 +1,239 @@
+import { Container } from 'react-bootstrap';
+import Form from '@organisms/Form';
+import * as yup from 'yup';
+import { FormDataInterface } from '@organisms/Form';
+import { ObjectPronounType, SubjectPronounType } from '@custom-types/pronouns';
+import { OBJECT_PRONOUNS, SUBJECT_PRONOUNS } from '@objects/pronouns';
+
+export interface RequestAidInterface {
+	name: string;
+	subjectPronoun: SubjectPronounType;
+	objectPronoun: ObjectPronounType;
+	language: string;
+	phone: string;
+	email: string;
+	preferredContactMethod: 'call' | 'text' | 'email';
+	location: string;
+	hasHearingDisability: boolean;
+	hasTransportation: boolean;
+	hasFluLikeSymptoms: boolean;
+	hasHealthCondition: boolean;
+	healthConditions: string;
+	is18: boolean;
+	needsPickup: boolean;
+	needsTransportation: boolean;
+	needsMedicalSupplies: boolean;
+	needsCleaningSupplies: boolean;
+	needsHomeCookedMeal: boolean;
+	needHomeCleaning: boolean;
+	needsCompanionship: boolean;
+	needsSocialServices: boolean;
+	needsPetCare: boolean;
+	needsOther: string;
+}
+
+const formData: Array<FormDataInterface> = [
+	{
+		name: 'name',
+		initialValue: '',
+		type: 'text',
+		validationSchema: yup.string().label('Name').required(),
+		label: 'Name',
+	},
+	{
+		name: 'subjectPronoun',
+		initialValue: 'they',
+		type: 'select',
+		options: SUBJECT_PRONOUNS,
+		validationSchema: yup.string().label('Subject Pronoun').required(),
+		label: 'Subject Pronoun',
+	},
+	{
+		name: 'objectPronoun',
+		initialValue: 'them',
+		type: 'select',
+		options: OBJECT_PRONOUNS,
+		validationSchema: yup.string().label('Object Pronoun').required(),
+		label: 'Object Pronoun',
+	},
+	{
+		name: 'language',
+		initialValue: 'English',
+		type: 'select',
+		options: ['English', 'Spanish', 'Vietnamese'],
+		validationSchema: yup.string().label('Language').required(),
+		label: 'Language',
+	},
+	{
+		name: 'phone',
+		initialValue: '',
+		type: 'text',
+		validationSchema: yup.string().label('Phone').required(),
+		label: 'Phone Number',
+	},
+	{
+		name: 'email',
+		initialValue: '',
+		type: 'text',
+		validationSchema: yup.string().label('Email').required(),
+		label: 'Email Address',
+	},
+	{
+		name: 'preferredContactMethod',
+		initialValue: 'Email',
+		type: 'select',
+		options: ['Email', 'Call', 'Text'],
+		validationSchema: yup.string().label('Email').required(),
+		label: 'Preferred Contact Method',
+	},
+	{
+		name: 'location',
+		initialValue: '',
+		type: 'text',
+		validationSchema: yup.string().label('Location').required(),
+		label: 'Location',
+	},
+	{
+		name: 'hasHearingDisability',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup
+			.string()
+			.label('Has Hearing Disability')
+			.required(),
+		label: 'Has Hearing Disability',
+	},
+	{
+		name: 'hasTransportation',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup.string().label('Has Transportation').required(),
+		label: 'Has Transportation',
+	},
+	{
+		name: 'hasFluLikeSymptoms',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup
+			.string()
+			.label('Has Flu Like Symptoms')
+			.required(),
+		label: 'Has Flu Like Symptoms',
+	},
+	{
+		name: 'hasHealthCondition',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup.string().label('Has Health Condition').required(),
+		label: 'Has Health Condition',
+	},
+	{
+		name: 'healthConditions',
+		initialValue: '',
+		type: 'text',
+		validationSchema: yup.string().label('Health Conditions').required(),
+		label: 'Health Conditions',
+	},
+	{
+		name: 'is18',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup.string().label('Is 18+').required(),
+		label: 'Is 18+',
+	},
+	{
+		name: 'needsPickup',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup.string().label('Needs Pickup').required(),
+		label: 'Needs Pickup',
+	},
+	{
+		name: 'needsTransportation',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup.string().label('Needs Transportation').required(),
+		label: 'Needs Transportation',
+	},
+	{
+		name: 'needsMedicalSupplies',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup
+			.string()
+			.label('Needs Medical Supplies')
+			.required(),
+		label: 'Needs Medical Supplies',
+	},
+	{
+		name: 'needsCleaningSupplies',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup
+			.string()
+			.label('Needs Cleaning Supplies')
+			.required(),
+		label: 'Needs Cleaning Supplies',
+	},
+	{
+		name: 'needsHomeCookedMeal',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup
+			.string()
+			.label('Needs Home Cooked Meal')
+			.required(),
+		label: 'Needs Home Cooked Meal',
+	},
+	{
+		name: 'needHomeCleaning',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup.string().label('Need Home Cleaning').required(),
+		label: 'Need Home Cleaning',
+	},
+	{
+		name: 'needsCompanionship',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup.string().label('Needs Companionship').required(),
+		label: 'Needs Companionship',
+	},
+	{
+		name: 'needsSocialServices',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup
+			.string()
+			.label('Needs Social Services')
+			.required(),
+		label: 'Needs Social Services',
+	},
+	{
+		name: 'needsPetCare',
+		initialValue: false,
+		type: 'checkbox',
+		validationSchema: yup.string().label('Needs Pet Care').required(),
+		label: 'Needs Pet Care',
+	},
+	{
+		name: 'needsOther',
+		initialValue: '',
+		type: 'text',
+		validationSchema: yup.string().label('Needs Other').required(),
+		label: 'Needs Other',
+	},
+];
+
+const Request = () => (
+	<Container>
+		<h1>Request Aid</h1>
+		<Form
+			data={formData}
+			onSubmit={(values: RequestAidInterface) => console.log({ values })}
+			submitButtonText="Submit Request"
+		/>
+	</Container>
+);
+
+export default Request;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,6 +12,7 @@ import DashboardOrders from '@pages/DashboardOrders';
 import DashboardSettings from '@pages/DashboardSettings';
 import DashboardAdmin from '@pages/DashboardAdmin';
 import ForgotPassword from '@pages/ForgotPassword';
+import Request from '@pages/Request';
 
 interface Route {
 	path: string;
@@ -70,6 +71,10 @@ const routes: Route[] = [
 	{
 		path: '/forgot-password',
 		element: <ForgotPassword />,
+	},
+	{
+		path: '/request',
+		element: <Request />,
 	},
 ];
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -22,22 +22,6 @@ p.is-danger {
 	color: var(--bs-danger);
 }
 
-form.standard-form input {
-	max-width: 500px;
-}
-
-form.standard-form input.input-sm {
-	max-width: 250px;
-}
-
-form.standard-form .form-select.select-sm {
-	max-width: 250px;
-}
-
-form.standard-form .form-select.select-sm {
-	max-width: 250px;
-}
-
 :root {
 	/* colors */
 	--white: #fff;


### PR DESCRIPTION
I've created a Form component that will make creating and maintaining forms easier. 

Now we can just create an array with the form data and pass it to the Form component:

```ts
{
	name: 'name',
	initialValue: '',
	type: 'text',
	validationSchema: yup.string().label('Name').required(),
	label: 'Name',
}
```