### PR TITLE
fix: moving interfaces to interfaces/form.ts and updating imports

### DIFF
--- a/interfaces/form.ts
+++ b/interfaces/form.ts
@@ -24,12 +24,3 @@ export interface FormPropsInterface {
 export interface InitialValueInterface {
 	[key: string]: string | number;
 }
-
-export interface StyledFormInterface {
-	className: string;
-	initialValues: InitialValueInterface;
-	validationSchema: yup.AnySchema;
-	onSubmit: any;
-	inputs: any;
-	submitButtonText?: string;
-}

--- a/interfaces/form.ts
+++ b/interfaces/form.ts
@@ -1,0 +1,35 @@
+import * as yup from 'yup';
+import { HTMLInputTypeAttribute } from "react";
+
+export interface InputInterface {
+	type: HTMLInputTypeAttribute;
+	name: string;
+	label: string;
+	options?: Array<string>;
+	placeholder?: string;
+	size?: 'xsm' | 'sm';
+}
+
+export interface FormDataInterface extends InputInterface {
+	initialValue: string | boolean;
+	validationSchema: yup.AnySchema;
+}
+
+export interface FormPropsInterface {
+	data: Array<FormDataInterface>;
+	onSubmit: any;
+	submitButtonText?: string;
+}
+
+export interface InitialValueInterface {
+	[key: string]: string | number;
+}
+
+export interface StyledFormInterface {
+	className: string;
+	initialValues: InitialValueInterface;
+	validationSchema: yup.AnySchema;
+	onSubmit: any;
+	inputs: any;
+	submitButtonText?: string;
+}

--- a/src/components/organisms/Form/index.tsx
+++ b/src/components/organisms/Form/index.tsx
@@ -3,7 +3,16 @@ import styled, { StyledComponent } from 'styled-components';
 import style from './style';
 import * as yup from 'yup';
 import { Button, Form as BSForm } from 'react-bootstrap';
-import { FormPropsInterface, InitialValueInterface, InputInterface, StyledFormInterface } from '@interfaces/form';
+import { FormPropsInterface, InitialValueInterface, InputInterface } from '@interfaces/form';
+
+interface StyledFormInterface {
+	className: string;
+	initialValues: InitialValueInterface;
+	validationSchema: yup.AnySchema;
+	onSubmit: any;
+	inputs: any;
+	submitButtonText?: string;
+}
 
 const StyledForm = styled(
 	({

--- a/src/components/organisms/Form/index.tsx
+++ b/src/components/organisms/Form/index.tsx
@@ -1,42 +1,9 @@
 import { Formik } from 'formik';
 import styled, { StyledComponent } from 'styled-components';
-import { HTMLInputTypeAttribute } from 'react';
 import style from './style';
 import * as yup from 'yup';
 import { Button, Form as BSForm } from 'react-bootstrap';
-
-export interface InputInterface {
-	type: HTMLInputTypeAttribute;
-	name: string;
-	label: string;
-	options?: Array<string>;
-	placeholder?: string;
-	size?: 'xsm' | 'sm';
-}
-
-export interface FormDataInterface extends InputInterface {
-	initialValue: string | boolean;
-	validationSchema: yup.AnySchema;
-}
-
-export interface FormPropsInterface {
-	data: Array<FormDataInterface>;
-	onSubmit: any;
-	submitButtonText?: string;
-}
-
-export interface InitialValueInterface {
-	[key: string]: string | number;
-}
-
-export interface StyledFormInterface {
-	className: string;
-	initialValues: InitialValueInterface;
-	validationSchema: yup.AnySchema;
-	onSubmit: any;
-	inputs: any;
-	submitButtonText?: string;
-}
+import { FormPropsInterface, InitialValueInterface, InputInterface, StyledFormInterface } from '@interfaces/form';
 
 const StyledForm = styled(
 	({

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -1,7 +1,7 @@
 import { Container } from 'react-bootstrap';
 import Form from '@organisms/Form';
 import * as yup from 'yup';
-import { FormDataInterface } from '@organisms/Form';
+import { FormDataInterface } from '@interfaces/form';
 import { OBJECT_PRONOUNS, SUBJECT_PRONOUNS } from '@objects/pronouns';
 import RequestAidInterface from '@interfaces/request-aid';
 


### PR DESCRIPTION
Most of the potential use cases for these interfaces will be in dynamic forms (after we finish v1 for sbma) and form components which can pull the required interfaces from `interfaces/form.ts`