### PR TITLE
fix: removed != messing up filters and added input group

### DIFF
--- a/src/api/get-requests.ts
+++ b/src/api/get-requests.ts
@@ -2,10 +2,10 @@ import { FiltersInterface } from '@interfaces/filters';
 import RequestAidInterface from '@interfaces/request-aid';
 import {
     getFirestore,
-    collection,
     getDocs,
     query,
     where,
+    collection,
 } from 'firebase/firestore';
 import app from './init-app';
 
@@ -14,33 +14,25 @@ const db = getFirestore(app);
 const getRequests = async (
     filters?: FiltersInterface
 ): Promise<{ [key: string]: RequestAidInterface }> => {
+    const { location, language, stage, driver } = filters;
+    const ref = collection(db, 'requests');
     const requests = {};
 
-    let q;
+    const wheres = [
+        location && where('location', '==', location),
+        language && where('language', '==', language),
+        where('stage', '==', stage || 'submitted'),
+        driver && where('hasDriver', '==', driver === 'assigned'),
+    ].filter((filter) => Boolean(filter) !== false);
 
-    if (filters) {
-        const { location, language, stage, driver } = filters;
-        const whereFilters = [
-            location && where('location', '==', location),
-            language && where('language', '==', language),
-            stage
-                ? where('stage', '==', stage)
-                : where('stage', '!=', 'complete'),
-            driver && where('hasDriver', '==', driver === 'assigned'),
-        ];
+    const q = query(ref, ...wheres);
 
-        q = query(
-            collection(db, 'requests'),
-            ...whereFilters.filter((filter) => Boolean(filter) !== false)
-        );
-    } else {
-        q = query(collection(db, 'requests'), where('stage', '!=', 'complete'));
-    }
+    const snapshot = await getDocs(q);
 
-    const querySnapshot = await getDocs(q);
-    querySnapshot.forEach((doc) => {
+    snapshot.forEach((doc) => {
         requests[doc.id] = doc.data();
     });
+
     return requests;
 };
 

--- a/src/forms/FilterForm/index.tsx
+++ b/src/forms/FilterForm/index.tsx
@@ -1,5 +1,5 @@
 import styled, { StyledComponent } from 'styled-components';
-import { Container, Row, Col, Button, Form } from 'react-bootstrap';
+import { Container, Row, Col, Button, Form, InputGroup } from 'react-bootstrap';
 import languages from '@objects/languages';
 import locations from '@objects/locations';
 import stages from '@objects/stages';
@@ -11,114 +11,103 @@ import style from './style';
 import { DriverKeyType } from '@custom-types/driver';
 import drivers from '@objects/drivers';
 
-const FilterForm: StyledComponent = styled(({
-    className,
-    filters,
-    setFilters,
-    setRefetch
-}: {
-    className: string,
-    filters: FiltersInterface,
-    setFilters: (value: FiltersInterface) => void,
-    setRefetch: (value: boolean) => void
-}) => {
-    return (
-        <Form className={className}>
-            <Container>
-                <Row>
-                    <Col>
-                        <Form.Group>
-                            <Form.Select
-                                as="select"
-                                name="locations"
-                                value={filters.location}
-                                size="sm"
-                                onChange={e => setFilters({
-                                    ...filters,
-                                    location: e.target.value as LocationKeyType
-                                })}
-                            >
-                                <option value={''}>Any Location</option>
-                                {
-                                    Object.entries(locations).map(([key, value]) => (
-                                        <option key={key} value={key}>{value}</option>
-                                    ))
-                                }
-                            </Form.Select>
-                        </Form.Group>
-                    </Col>
-                    <Col>
-                        <Form.Group>
-                            <Form.Select
-                                as="select"
-                                name="languages"
-                                value={filters.language}
-                                size="sm"
-                                onChange={e => setFilters({
-                                    ...filters,
-                                    language: e.target.value as LanguageKeyType
-                                })}
-                            >
-                                <option value={''}>Any Language</option>
-                                {
-                                    Object.entries(languages).map(([key, value]) => (
-                                        <option key={key} value={key}>{value}</option>
-                                    ))
-                                }
-                            </Form.Select>
-                        </Form.Group>
-                    </Col>
-                    <Col>
-                        <Form.Group>
-                            <Form.Select
-                                as="select"
-                                name="driver"
-                                value={filters.driver}
-                                size="sm"
-                                onChange={e => setFilters({
-                                    ...filters,
-                                    driver: e.target.value as DriverKeyType
-                                })}
-                            >
-                                <option value={''}>Any Driver</option>
-                                {
-                                    Object.entries(drivers).map(([key, value]) => (
-                                        <option key={key} value={key}>{value}</option>
-                                    ))
-                                }
-                            </Form.Select>
-                        </Form.Group>
-                    </Col>
-                    <Col>
-                        <Form.Group>
-                            <Form.Select
-                                as="select"
-                                name="stages"
-                                value={filters.stage}
-                                size="sm"
-                                onChange={e => setFilters({
-                                    ...filters,
-                                    stage: e.target.value as StageKeyType
-                                })}
-                            >
-                                <option value={''}>Any Stage</option>
-                                {
-                                    Object.entries(stages).map(([key, value]) => (
-                                        <option key={key} value={key}>{value}</option>
-                                    ))
-                                }
-                            </Form.Select>
-                        </Form.Group>
-                    </Col>
-                    <Col>
-                        <Button size="sm" onClick={() => setRefetch(true)}>
-                            Apply <span className="tablet-remove">Filters</span>
-                        </Button>
-                    </Col>
-                </Row>
-            </Container>
-        </Form>
-    );
-})(style);
+const FilterForm: StyledComponent = styled(
+    ({
+        className,
+        filters,
+        setFilters,
+        setRefetch,
+    }: {
+        className: string;
+        filters: FiltersInterface;
+        setFilters: (value: FiltersInterface) => void;
+        setRefetch: (value: boolean) => void;
+    }) => {
+        return (
+            <Form className={className}>
+                <InputGroup>
+                    <Form.Select
+                        as="select"
+                        name="locations"
+                        value={filters.location}
+                        size="sm"
+                        onChange={(e) =>
+                            setFilters({
+                                ...filters,
+                                location: e.target.value as LocationKeyType,
+                            })
+                        }
+                    >
+                        <option value={''}>Any Location</option>
+                        {Object.entries(locations).map(([key, value]) => (
+                            <option key={key} value={key}>
+                                {value}
+                            </option>
+                        ))}
+                    </Form.Select>
+                    <Form.Select
+                        as="select"
+                        name="languages"
+                        value={filters.language}
+                        size="sm"
+                        onChange={(e) =>
+                            setFilters({
+                                ...filters,
+                                language: e.target.value as LanguageKeyType,
+                            })
+                        }
+                    >
+                        <option value={''}>Any Language</option>
+                        {Object.entries(languages).map(([key, value]) => (
+                            <option key={key} value={key}>
+                                {value}
+                            </option>
+                        ))}
+                    </Form.Select>
+                    <Form.Select
+                        as="select"
+                        name="driver"
+                        value={filters.driver}
+                        size="sm"
+                        onChange={(e) =>
+                            setFilters({
+                                ...filters,
+                                driver: e.target.value as DriverKeyType,
+                            })
+                        }
+                    >
+                        <option value={''}>Any Driver</option>
+                        {Object.entries(drivers).map(([key, value]) => (
+                            <option key={key} value={key}>
+                                {value}
+                            </option>
+                        ))}
+                    </Form.Select>
+                    <Form.Select
+                        as="select"
+                        name="stages"
+                        value={filters.stage}
+                        size="sm"
+                        onChange={(e) =>
+                            setFilters({
+                                ...filters,
+                                stage: e.target.value as StageKeyType,
+                            })
+                        }
+                    >
+                        {Object.entries(stages).map(([key, value]) => (
+                            <option key={key} value={key}>
+                                {value}
+                            </option>
+                        ))}
+                    </Form.Select>
+                    <Button size="sm" onClick={() => setRefetch(true)}>
+                        Apply <span className="tablet-remove">Filters</span>
+                    </Button>
+                </InputGroup>
+            </Form>
+        );
+    }
+)(style);
 
 export default FilterForm;

--- a/src/forms/FilterForm/style.ts
+++ b/src/forms/FilterForm/style.ts
@@ -1,24 +1,7 @@
 const style = () => ({
-    '.container': {
-        paddingTop: '8px',
-        paddingBottom: '8px',
-    },
-    '.row': {
-        gap: '8px',
-    },
-    '.col': {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        padding: '0',
-    },
-    '.col > div, button': {
-        width: '100%',
-    },
-    '@media only screen and (max-width: 576px)': {
-        '.row': {
-            flexDirection: 'column',
-        },
+    margin: '15px 0px',
+    'select, button': {
+        cursor: 'pointer',
     },
 });
 

--- a/src/pages/Dashboard/AidRequestsPage.tsx
+++ b/src/pages/Dashboard/AidRequestsPage.tsx
@@ -19,7 +19,7 @@ const AidRequestsPage = () => {
         location: '',
         language: '',
         driver: '',
-        stage: '',
+        stage: 'submitted',
     });
     const handler = (id?: string, shouldRefetch?: boolean): void => {
         setSelected(id);


### PR DESCRIPTION
Not my favorite solution but it will have to work for now.

You can't mix "==" and "!=" in a single query.

We relied on the "!=" to give us all requests not in the ``complete`` stage. 

Since we can't mix operators, I'm defaulting to ``submitted``. 

That way the users are greeted with newly submitted requests. 

NOTE: We need to make it so volunteer can become the "coordinator" of a request. That way we can filter all requests that are equal to their UID and it'll make it easier for volunteers to track requests they're working on. We can follow the same pattern as what we did with the driver by adding ``hasCoordinator`` and ``coordinator`` keys.