### PR TITLE
fix: moving styles to theme

### DIFF
--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -16,7 +16,7 @@ const Tooltip: StyledComponent = styled(({
 }) => {
 	return (
 		<span className={className}>
-			<OverlayTrigger delay={{show:0, hide: 50000}}
+			<OverlayTrigger
 				placement={position}
 				overlay={
 					<RBTooltip id={`tooltip-${position}`}>

--- a/src/components/Tooltip/style.ts
+++ b/src/components/Tooltip/style.ts
@@ -2,10 +2,6 @@ const style = () => ({
     img: {
         cursor: 'pointer',
         animationDelay: '1s',
-    },
-    '.tooltip-inner-container': {
-        padding: '10px',
-        textAlign: 'start'
     }
 });
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -54,6 +54,11 @@ h1 {
     font-weight: 900;
 }
 
+.tooltip-inner-container {
+    padding: 10px;
+    text-align: start;
+}
+
 @media only screen and (max-width: 576px) {
     .mobile-remove {
         display: none;


### PR DESCRIPTION
Sorry, I think there was a miscommunication in the last pr, the styles committed (in `/src/Tooltip/style.ts`) were not being applied to the tooltips. I just committed it to illustrate https://github.com/jadeallencook/communalists/pull/40#discussion_r1111134163 comment. 

I've moved them back to `theme.css` so they properly apply. We can keep it like this or move it inline.