### PR TITLE
fix: add overflow hidden to navbar

### DIFF
--- a/src/components/Navigation/style.ts
+++ b/src/components/Navigation/style.ts
@@ -1,5 +1,6 @@
 const style = () => ({
     backgroundColor: 'var(--primary)!important',
+    overflow: 'hidden',
     '.navbar-brand': {
         fontWeight: 'bold',
     },


### PR DESCRIPTION
The off-canvas component causes an overflow in the navbar allowing users to scroll right. This seems to fix it without affecting function but please check when reviewing.