### PR TITLE
fix: language dropdown is no longer hidden

### DIFF
--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -118,52 +118,60 @@ const Navigation: StyledComponent = styled(({ className }) => {
     const toggleMobileNavigation = () =>
         setIsMobileNavigationOpen(!isMobileNavigationOpen);
     return (
-        <Navbar
-            bg="dark"
-            variant="dark"
-            sticky="top"
-            className={`${className} animate__animated animate__slideInDown`}
-            expand={false}
-        >
-            <Container>
-                <Navbar.Brand>
-                    <Link to="/">
-                        <img
-                            src={LogoPNG}
-                            style={{ animationDelay: '.5s' }}
-                            className="animate__animated animate__rotateIn"
-                        />
-                        <span className="tablet-remove">
-                            {snippet('communalists')}
-                        </span>
-                    </Link>
-                </Navbar.Brand>
-                <Links className="justify-content-end tablet-remove desktop-links" />
-                <Navbar.Toggle
-                    className="tablet-show"
-                    aria-controls={`offcanvasNavbar-expand`}
-                    onClick={toggleMobileNavigation}
-                />
-                <Navbar.Offcanvas
-                    id={`offcanvasNavbar-expand`}
-                    aria-labelledby={`offcanvasNavbarLabel-expand`}
-                    placement="end"
-                    show={isMobileNavigationOpen}
-                    onHide={toggleMobileNavigation}
-                >
-                    <Offcanvas.Header closeButton>
-                        <Offcanvas.Title id={`offcanvasNavbarLabel-expand`}>
-                            <b>{snippet('communalists')}</b>
-                        </Offcanvas.Title>
-                    </Offcanvas.Header>
-                    <Offcanvas.Body>
-                        <Links
-                            toggleMobileNavigation={toggleMobileNavigation}
-                        />
-                    </Offcanvas.Body>
-                </Navbar.Offcanvas>
-            </Container>
-        </Navbar>
+        <>
+            <Navbar
+                bg="dark"
+                variant="dark"
+                sticky="top"
+                className={`${className} animate__animated animate__slideInDown`}
+                expand={false}
+            >
+                <Container>
+                    <Navbar.Brand>
+                        <Link to="/">
+                            <img
+                                src={LogoPNG}
+                                style={{ animationDelay: '.5s' }}
+                                className="animate__animated animate__rotateIn"
+                            />
+                            <span className="tablet-remove">
+                                {snippet('communalists')}
+                            </span>
+                        </Link>
+                    </Navbar.Brand>
+                    <Links className="justify-content-end tablet-remove desktop-links" />
+                    <Navbar.Toggle
+                        className="tablet-show"
+                        aria-controls={`offcanvasNavbar-expand`}
+                        onClick={toggleMobileNavigation}
+                    />
+                </Container>
+            </Navbar>
+
+            {/* This needs to be separated from the `NavBar` above;
+                when it's a child, the page grows horizontally and
+                we get a scrollbar past the end of the page, to the right.
+             */}
+            <Navbar.Offcanvas
+                id={`offcanvasNavbar-expand`}
+                aria-labelledby={`offcanvasNavbarLabel-expand`}
+                placement="end"
+                show={isMobileNavigationOpen}
+                onHide={toggleMobileNavigation}
+            >
+                <Offcanvas.Header closeButton>
+                    <Offcanvas.Title id={`offcanvasNavbarLabel-expand`}>
+                        <b>{snippet('communalists')}</b>
+                    </Offcanvas.Title>
+                </Offcanvas.Header>
+                <Offcanvas.Body>
+                    <Links
+                        className={'flex-column'}
+                        toggleMobileNavigation={toggleMobileNavigation}
+                    />
+                </Offcanvas.Body>
+            </Navbar.Offcanvas>
+        </>
     );
 })(style);
 

--- a/src/components/Navigation/style.ts
+++ b/src/components/Navigation/style.ts
@@ -1,6 +1,5 @@
 const style = () => ({
     backgroundColor: 'var(--primary)!important',
-    overflow: 'hidden',
     '.navbar-brand': {
         fontWeight: 'bold',
     },


### PR DESCRIPTION
[This previous PR](https://github.com/jadeallencook/communalists/pull/64) added the `overflow: hidden` to fix horizontal scrolling. This fixed the scrolling but unfortunately made the language-picker dropdown unusable.

Afaict, it's not possible to have dropdowns that extend past the parent while enabling `overflow`. I found https://stackoverflow.com/questions/6421966/css-overflow-x-visible-and-overflow-y-hidden-causing-scrollbar-issue which seems to imply that this is a behavior of the spec and there's no way to use `overflow` for this problem.

So I deleted the `overflow` attribute, and then to fix the horizontal scrolling, I moved the `OffCanvas` component to not be a child of `Navbar`.

I have absolutely no idea why that worked. I looked at a few examples, tried narrowing down edge cases, I have absolutely no idea why the `OffCanvas` was doing that to begin with. However, moving it out of the descendants of `Navbar` worked. Either way, I added a comment to mark it down.

## Testing
Previous behavior: https://www.loom.com/share/21efb84276004d1eb4e5804572add21b
New behavior: https://www.loom.com/share/a63fa52f28ce4a758ebc9448897fd941


