### PR TITLE
fix: snippet context refactor

### DIFF
--- a/src/contexts/SnippetContext.tsx
+++ b/src/contexts/SnippetContext.tsx
@@ -13,25 +13,9 @@ const SnippetContext = createContext<SnippetContextInterface>(null);
 export const SnippetProvider = ({ children }) => {
     const [language, setLanguage] = useState<LanguageKeyType>('english');
 
-    const snippet = (path: string, page?: ComponentType): string => {
-        if (!page) {
-            page = 'shared';
-        }
-        let snip = [page, path, language].reduce(
-            (value: any, key: string) =>
-                value[key] && value !== '' ? value[key] : '',
-            snippets
-        );
-
-        if (!snip && language !== 'english') {
-            snip = [page, path, 'english'].reduce(
-                (value: any, key: string) =>
-                    value[key] && value !== '' ? value[key] : '',
-                snippets
-            );
-        }
-
-        return typeof snip !== 'string' ? '' : snip;
+    const snippet = (path: string, page: ComponentType = 'shared'): string => {
+        const snip = snippets[page][path];
+        return snip?.[language] ?? snip?.['english'] ?? '';
     };
 
     return (


### PR DESCRIPTION
This PR uses some of the nullish operators (`a?.[]` and `??`) to reduce the number of operations necessary to find the right language. This also happens to reduce the amount of code as well.