### PR TITLE
feat: add a format check to ci, which runs on all branches

### DIFF
--- a/.github/workflows/ci-formatting.yml
+++ b/.github/workflows/ci-formatting.yml
@@ -1,0 +1,39 @@
+name: Check Formatting
+on: [push]
+
+jobs:
+  check-ts-format:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: node-version
+        name: Get node version
+        run: |
+          echo "version=`cat .nvmrc`" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js for use with actions
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.node-version.outputs.version }}
+
+      - name: Install Node.js dependencies
+        run: |
+          npm install
+
+          if ! test -z "`git diff --stat`"; then
+            echo "`npm install` produced changes, exiting"
+            git diff --name-only | cat
+            exit 1
+          fi
+
+      - name: Check Formatting
+        run: |
+          npm run pretty --write "./**/*.{ts,tsx,css,json}"
+
+          if ! test -z "`git diff --stat`"; then
+            echo "`prettier` produced changes, exiting"
+            git diff --name-only | cat
+            exit 1
+          fi


### PR DESCRIPTION
Adds a formatting check to all pushes on CI. Implemented by first running `npm run pretty` and then checking whether files changed after formatting.

NOTE: @jadeallencook you may need to add some rules in the repository itself once this PR merges, so that PRs need all CI checks to pass before merging. Alternatively, the check by itself may still be useful during review.