### PR TITLE
feat: use development firestore in dev-mode

### DIFF
--- a/src/api/init-app.ts
+++ b/src/api/init-app.ts
@@ -1,13 +1,16 @@
 import { initializeApp } from 'firebase/app';
 
-const app = initializeApp({
-    apiKey: 'AIzaSyBBKtH-EEIOp-0HVpOhQDgr_RKCOeIeXt0',
-    authDomain: 'communalists.firebaseapp.com',
-    projectId: 'communalists',
-    storageBucket: 'communalists.appspot.com',
-    messagingSenderId: '895012652302',
-    appId: '1:895012652302:web:1472a663bf95e88ad1c35f',
-    measurementId: 'G-41Q7T9V1ZW',
-});
+const app = initializeApp(
+    (!!process.env.FIREBASE_CONFIG &&
+        JSON.parse(process.env.FIREBASE_CONFIG)) || {
+        apiKey: 'AIzaSyAPLOZVUrbC3K6YK72IW0wBufCOLZcEEhY',
+        authDomain: 'communalists-test.firebaseapp.com',
+        projectId: 'communalists-test',
+        storageBucket: 'communalists-test.appspot.com',
+        messagingSenderId: '697702436149',
+        appId: '1:697702436149:web:5cc3ac450c6ef3e54f107c',
+        measurementId: 'G-K6JB24D6F1',
+    }
+);
 
 export default app;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 const path = require('path');
 
 module.exports = {
@@ -11,6 +12,13 @@ module.exports = {
 		new HtmlWebpackPlugin({
 			template: './public/index.html',
 		}),
+
+        new webpack.EnvironmentPlugin({
+			// null here indicates an optional environment variable;
+			// this one is used by init-app.ts, and defaults to
+			// the `communalists-test` backend when not provided.
+			 FIREBASE_CONFIG: null,
+        }),
 	],
 	resolve: {
 		modules: [__dirname, 'src', 'node_modules'],


### PR DESCRIPTION
Use development firestore configurations when not in production mode. Addresses #72 

I can't access the vercel deployments config but I've added a script for building the app in dev-mode.

Also, it seems that some bits of the `communalists-test` firestore instance haven't been set up; I get an error when logging in under the dev mode now (`Firebase: Error (auth/configuration-not-found)`).