### PR TITLE
feat: add new stage 'cancelled'

### DIFF
--- a/objects/stages.ts
+++ b/objects/stages.ts
@@ -5,6 +5,7 @@ const stages: { [key in StageKeyType]: StageType } = {
     started: 'Coordinating (2/4)',
     ready: 'Ready (3/4)',
     complete: 'Fulfilled (4/4)',
+    cancelled: 'Cancelled',
 };
 
 export default stages;

--- a/src/components/RequestsTable/style.ts
+++ b/src/components/RequestsTable/style.ts
@@ -18,7 +18,7 @@ const style = () => ({
     'span.ready, span.has-driver': {
         backgroundColor: 'var(--primary)!important',
     },
-    'span.complete': {
+    'span.complete, span.cancelled': {
         backgroundColor: 'grey!important',
     },
     'span.has-no-driver, span.submitted': {

--- a/types/stages.ts
+++ b/types/stages.ts
@@ -1,7 +1,13 @@
-export type StageKeyType = 'submitted' | 'started' | 'ready' | 'complete';
+export type StageKeyType =
+    | 'submitted'
+    | 'started'
+    | 'ready'
+    | 'complete'
+    | 'cancelled';
 
 export type StageType =
     | 'Received (1/4)'
     | 'Coordinating (2/4)'
     | 'Ready (3/4)'
-    | 'Fulfilled (4/4)';
+    | 'Fulfilled (4/4)'
+    | 'Cancelled';


### PR DESCRIPTION
The Cancelled stage functions as shown below as per the suggestion from nic:

<img width="1440" alt="Screen Shot 2023-05-30 at 7 35 56 PM" src="https://github.com/jadeallencook/communalists/assets/18740303/80839a02-48fc-45a4-9ed8-bff9df5d2789">


<img width="1439" alt="Screen Shot 2023-05-30 at 7 36 05 PM" src="https://github.com/jadeallencook/communalists/assets/18740303/c98aba67-ac2a-4d32-aa1d-668b34f7b22d">
