### PR TITLE
Setting Up Firebase Emulators and Rules Locally

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "communalists"
+  }
+}

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "displayNames": {
+     ".read": true,
+     "$uid": {
+        ".write": "auth !== null && auth.uid === $uid"
+    	}
+    },
+    "requestFormStatus": {
+     ".read": true,
+     ".write": "auth !== null"
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,33 @@
+{
+    "database": {
+        "rules": "database.rules.json"
+    },
+    "firestore": {
+        "rules": "firestore.rules",
+        "indexes": "firestore.indexes.json"
+    },
+    "storage": {
+        "rules": "storage.rules"
+    },
+    "emulators": {
+        "auth": {
+            "port": 9099
+        },
+        "firestore": {
+            "port": 8080
+        },
+        "database": {
+            "port": 9000
+        },
+        "hosting": {
+            "port": 5000
+        },
+        "storage": {
+            "port": 9199
+        },
+        "ui": {
+            "enabled": true
+        },
+        "singleProjectMode": true
+    }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,49 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "language",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "location",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "stage",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "driver",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "location",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "language",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "stage",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "hasDriver",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,45 @@
+rules_version = '2';
+service cloud.firestore {
+
+  match /databases/{database}/documents {
+  
+  	function isUserMemberOfSBMA() {
+  		let uid = request.auth.uid;
+      let SBMA = "I8Myn7qqYInyIo8aOiHs";
+   		return uid in get(/databases/$(database)/documents/organizations/$(SBMA)).data.members;
+  	}
+    
+    function isUserModeratorOfSBMA() {
+  		let uid = request.auth.uid;
+      let SBMA = "test123";
+   		return uid in get(/databases/$(database)/documents/organizations/$(SBMA)).data.moderators;
+  	}
+    
+    match /requests/{requestId} {
+    	allow create: if resource == null; 
+      allow read, write: if isUserMemberOfSBMA();
+    }
+    
+    match /donations/{requestId} {
+    	allow create: if resource == null; 
+      allow read, write: if isUserMemberOfSBMA();
+    }
+    
+    match /threads/{threadId} {
+    	allow create: if resource == null; 
+      allow read, write: if isUserMemberOfSBMA();
+    }
+    
+    match /organizations/{organizationId} {
+    	allow read;
+      allow write: if request.auth != null;
+    }
+    
+    match /{document=**} {
+    	allow create: if resource == null; 
+      allow read, write: if isUserMemberOfSBMA();
+    }
+    
+  }
+}
+

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Document</title>
+        <title>Communalists | Building Stronger Communities Together</title>
     </head>
     <body>
         <div id="root"></div>

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+
+// Craft rules based on data in your Firestore database
+// allow write: if firestore.get(
+//    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
I've set up Firebase emulators and rules locally using the Firebase CLI. This setup allows us to test our backend features in a local environment, closely mirroring our production setup. 