### PR TITLE
Migrating Our Custom Color Scheme to Mantine

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,3 @@
+body {
+    background-color: #212529;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import { createRoot } from 'react-dom/client';
 import Router from './router';
 import Layout from './layout';
 import Mantine from './mantine';
+import './global.css';
 
 const App = () => (
     <Mantine>

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -6,8 +6,8 @@
 
 import React from 'react';
 
-const Layout = ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-);
+const Layout = ({ children }: { children: React.ReactNode }) => {
+    return <div>{children}</div>;
+};
 
 export default Layout;

--- a/src/mantine.tsx
+++ b/src/mantine.tsx
@@ -8,7 +8,37 @@ import React from 'react';
 import '@mantine/core/styles.css';
 import { MantineProvider, createTheme } from '@mantine/core';
 
-const theme = createTheme({});
+const theme = createTheme({
+    white: '#fff',
+    black: '#000',
+    primaryColor: 'red',
+    colors: {
+        red: [
+            '#e4afa0',
+            '#de9b88',
+            '#d78770',
+            '#d07358',
+            '#c95f41',
+            '#c34b29',
+            '#bc3711',
+            '#a9320f',
+            '#962c0e',
+            '#84270c',
+        ],
+        gray: [
+            '#a6a8a9',
+            '#909294',
+            '#7a7c7f',
+            '#646669',
+            '#4d5154',
+            '#373b3e',
+            '#212529',
+            '#1e2125',
+            '#1a1e21',
+            '#171a1d',
+        ],
+    },
+});
 
 const Mantine = ({ children }: { children: React.ReactNode }) => (
     <MantineProvider theme={theme}>{children}</MantineProvider>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,6 +12,7 @@ import {
     Route,
     RootRoute,
 } from '@tanstack/react-router';
+import { Button } from '@mantine/core';
 
 const rootRoute = new RootRoute({
     component: () => <Outlet />,
@@ -20,7 +21,11 @@ const rootRoute = new RootRoute({
 const indexRoute = new Route({
     getParentRoute: () => rootRoute,
     path: '/',
-    component: () => <h1>Hello World</h1>,
+    component: () => (
+        <>
+            <Button>Test Button</Button>
+        </>
+    ),
 });
 
 const routeTree = rootRoute.addChildren([indexRoute]);


### PR DESCRIPTION
Set up Mantine in our project and migrated some of our colors from version 1.0 into the theme provider. This means we can keep our brand colors while taking advantage of Mantine UI components.

<img width="186" alt="Screenshot 2023-12-21 at 11 47 31 PM" src="https://github.com/jadeallencook/communalists/assets/4443883/c2bda0be-5c32-4e8c-a1b5-a96a9ca28736">

I'm excited to see how this version looks with the new components. 