### PR TITLE
Switched Default Color Scheme on Mantine Provider to Dark

### DIFF
--- a/src/base/Mantine.tsx
+++ b/src/base/Mantine.tsx
@@ -41,7 +41,9 @@ const theme = createTheme({
 });
 
 const Mantine = ({ children }: { children: React.ReactNode }) => (
-    <MantineProvider theme={theme}>{children}</MantineProvider>
+    <MantineProvider defaultColorScheme="dark" theme={theme}>
+        {children}
+    </MantineProvider>
 );
 
 export default Mantine;


### PR DESCRIPTION
Updated the color scheme to dark on the Mantine provider to match the previous branding.

<img width="1474" alt="Screenshot 2023-12-24 at 4 45 14 PM" src="https://github.com/jadeallencook/communalists/assets/4443883/59e0f5ac-f28e-48b2-87cd-a7ee550fc360">

<img width="806" alt="Screenshot 2023-12-24 at 4 47 16 PM" src="https://github.com/jadeallencook/communalists/assets/4443883/6ec1fdd3-495a-4452-84d8-0c139d8a2b93">
